### PR TITLE
Fix #131:  Add customizable inner gaps and outer gaps

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
@@ -32,16 +32,49 @@
             <summary>Shows indicator</summary>
             <description>Shows an indicator on top panel.</description>
         </key>
-        <key name="inner-gaps" type="u">
+
+        <key name="inner-gaps-top" type="u">
             <default>16</default>
-            <summary>Inner gaps</summary>
-            <description>Internal gaps between tiles in a layout.</description>
+            <summary>Inner top gap</summary>
+            <description>Gap at the top between windows</description>
         </key>
-        <key name="outer-gaps" type="u">
+        <key name="inner-gaps-bottom" type="u">
+            <default>16</default>
+            <summary>Inner bottom gap</summary>
+            <description>Gap at the bottom between windows</description>
+        </key>
+        <key name="inner-gaps-left" type="u">
+            <default>16</default>
+            <summary>Inner left gap</summary>
+            <description>Gap on the left side between windows</description>
+        </key>
+        <key name="inner-gaps-right" type="u">
+            <default>16</default>
+            <summary>Inner right gap</summary>
+            <description>Gap on the right side between windows</description>
+        </key>
+
+        <key name="outer-gaps-top" type="u">
             <default>8</default>
-            <summary>Outer gaps</summary>
-            <description>External gaps between the layout and the monitor borders.</description>
+            <summary>Outer top gap</summary>
+            <description>Gap between windows and top monitor border</description>
         </key>
+        <key name="outer-gaps-bottom" type="u">
+            <default>8</default>
+            <summary>Outer bottom gap</summary>
+            <description>Gap between windows and bottom monitor border</description>
+        </key>
+        <key name="outer-gaps-left" type="u">
+            <default>8</default>
+            <summary>Outer left gap</summary>
+            <description>Gap between windows and left monitor border</description>
+        </key>
+        <key name="outer-gaps-right" type="u">
+            <default>8</default>
+            <summary>Outer right gap</summary>
+            <description>Gap between windows and right monitor border</description>
+        </key>
+
         <key name="enable-span-multiple-tiles" type="b">
             <default>true</default>
             <summary>Span multiple tiles</summary>

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -60,19 +60,81 @@ export default class TilingShellExtensionPreferences extends ExtensionPreference
         );
         appearenceGroup.add(showIndicatorRow);
 
-        const innerGapsRow = this._buildSpinButtonRow(
-            Settings.KEY_INNER_GAPS,
-            _('Inner gaps'),
-            _('Gaps between windows'),
-        );
+        // Expandable inner gaps row (dropdown)
+        const innerGapsRow = new Adw.ExpanderRow({
+            title: _('Inner gaps'),
+            subtitle: _('Gaps between windows'),
+        });
         appearenceGroup.add(innerGapsRow);
 
-        const outerGapsRow = this._buildSpinButtonRow(
-            Settings.KEY_OUTER_GAPS,
-            _('Outer gaps'),
-            _('Gaps between a window and the monitor borders'),
+        // Inner gaps controls
+        innerGapsRow.add_row(
+            this._buildSpinButtonRow(
+                Settings.KEY_INNER_GAPS_LEFT,
+                _('Left'),
+                _('Gap on the left side between windows'),
+            )
         );
+        innerGapsRow.add_row(
+            this._buildSpinButtonRow(
+                Settings.KEY_INNER_GAPS_RIGHT,
+                _('Right'),
+                _('Gap on the right side between windows'),
+            )
+        );
+        innerGapsRow.add_row(
+            this._buildSpinButtonRow(
+                Settings.KEY_INNER_GAPS_TOP,
+                _('Top'),
+                _('Gap at the top between windows'),
+            )
+        );
+        innerGapsRow.add_row(
+            this._buildSpinButtonRow(
+                Settings.KEY_INNER_GAPS_BOTTOM,
+                _('Bottom'),
+                _('Gap at the bottom between windows'),
+            )
+        );
+
+        // Expandable outer gaps row (dropdown)
+        const outerGapsRow = new Adw.ExpanderRow({
+            title: _('Outer gaps'),
+            subtitle: _('Gaps between windows and monitor borders'),
+        });
         appearenceGroup.add(outerGapsRow);
+
+        // Outer gaps controls
+        outerGapsRow.add_row(
+            this._buildSpinButtonRow(
+                Settings.KEY_OUTER_GAPS_LEFT,
+                _('Left'),
+                _('Gap between windows and left monitor border'),
+            )
+        );
+        outerGapsRow.add_row(
+            this._buildSpinButtonRow(
+                Settings.KEY_OUTER_GAPS_RIGHT,
+                _('Right'),
+                _('Gap between windows and right monitor border'),
+            )
+        );
+        outerGapsRow.add_row(
+            this._buildSpinButtonRow(
+                Settings.KEY_OUTER_GAPS_TOP,
+                _('Top'),
+                _('Gap between windows and top monitor border'),
+            )
+        );
+        outerGapsRow.add_row(
+            this._buildSpinButtonRow(
+                Settings.KEY_OUTER_GAPS_BOTTOM,
+                _('Bottom'),
+                _('Gap between windows and bottom monitor border'),
+            )
+        );
+
+
 
         const blurRow = new Adw.ExpanderRow({
             title: _('Blur (experimental feature)'),

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -101,8 +101,17 @@ export default class Settings {
     static KEY_OVERRIDE_WINDOW_MENU = 'override-window-menu';
     static KEY_SNAP_ASSISTANT_THRESHOLD = 'snap-assistant-threshold';
     static KEY_ENABLE_WINDOW_BORDER = 'enable-window-border';
-    static KEY_INNER_GAPS = 'inner-gaps';
-    static KEY_OUTER_GAPS = 'outer-gaps';
+
+    static KEY_INNER_GAPS_TOP = 'inner-gaps-top';
+    static KEY_INNER_GAPS_BOTTOM = 'inner-gaps-bottom';
+    static KEY_INNER_GAPS_LEFT = 'inner-gaps-left';
+    static KEY_INNER_GAPS_RIGHT = 'inner-gaps-right';
+    
+    static KEY_OUTER_GAPS_TOP = 'outer-gaps-top';
+    static KEY_OUTER_GAPS_BOTTOM = 'outer-gaps-bottom';
+    static KEY_OUTER_GAPS_LEFT = 'outer-gaps-left';
+    static KEY_OUTER_GAPS_RIGHT = 'outer-gaps-right';
+
     static KEY_SNAP_ASSISTANT_ANIMATION_TIME = 'snap-assistant-animation-time';
     static KEY_TILE_PREVIEW_ANIMATION_TIME = 'tile-preview-animation-time';
     static KEY_SETTING_LAYOUTS_JSON = 'layouts-json';
@@ -226,20 +235,68 @@ export default class Settings {
         set_activationkey(Settings.KEY_TILING_SYSTEM_DEACTIVATION_KEY, val);
     }
 
-    static get INNER_GAPS(): number {
-        return get_unsigned_number(Settings.KEY_INNER_GAPS);
+    static get INNER_GAPS_TOP(): number {
+        return get_unsigned_number(Settings.KEY_INNER_GAPS_TOP);
     }
 
-    static set INNER_GAPS(val: number) {
-        set_unsigned_number(Settings.KEY_INNER_GAPS, val);
+    static set INNER_GAPS_TOP(val: number) {
+        set_unsigned_number(Settings.KEY_INNER_GAPS_TOP, val);
     }
 
-    static get OUTER_GAPS(): number {
-        return get_unsigned_number(Settings.KEY_OUTER_GAPS);
+    static get INNER_GAPS_BOTTOM(): number {
+        return get_unsigned_number(Settings.KEY_INNER_GAPS_BOTTOM);
     }
 
-    static set OUTER_GAPS(val: number) {
-        set_unsigned_number(Settings.KEY_OUTER_GAPS, val);
+    static set INNER_GAPS_BOTTOM(val: number) {
+        set_unsigned_number(Settings.KEY_INNER_GAPS_BOTTOM, val);
+    }
+
+    static get INNER_GAPS_LEFT(): number {
+        return get_unsigned_number(Settings.KEY_INNER_GAPS_LEFT);
+    }
+
+    static set INNER_GAPS_LEFT(val: number) {
+        set_unsigned_number(Settings.KEY_INNER_GAPS_LEFT, val);
+    }
+
+    static get INNER_GAPS_RIGHT(): number {
+        return get_unsigned_number(Settings.KEY_INNER_GAPS_RIGHT);
+    }
+
+    static set INNER_GAPS_RIGHT(val: number) {
+        set_unsigned_number(Settings.KEY_INNER_GAPS_RIGHT, val);
+    }
+
+    static get OUTER_GAPS_TOP(): number {
+        return get_unsigned_number(Settings.KEY_OUTER_GAPS_TOP);
+    }
+
+    static set OUTER_GAPS_TOP(val: number) {
+        set_unsigned_number(Settings.KEY_OUTER_GAPS_TOP, val);
+    }
+
+    static get OUTER_GAPS_BOTTOM(): number {
+        return get_unsigned_number(Settings.KEY_OUTER_GAPS_BOTTOM);
+    }
+
+    static set OUTER_GAPS_BOTTOM(val: number) {
+        set_unsigned_number(Settings.KEY_OUTER_GAPS_BOTTOM, val);
+    }
+
+    static get OUTER_GAPS_LEFT(): number {
+        return get_unsigned_number(Settings.KEY_OUTER_GAPS_LEFT);
+    }
+
+    static set OUTER_GAPS_LEFT(val: number) {
+        set_unsigned_number(Settings.KEY_OUTER_GAPS_LEFT, val);
+    }
+
+    static get OUTER_GAPS_RIGHT(): number {
+        return get_unsigned_number(Settings.KEY_OUTER_GAPS_RIGHT);
+    }
+
+    static set OUTER_GAPS_RIGHT(val: number) {
+        set_unsigned_number(Settings.KEY_OUTER_GAPS_RIGHT, val);
     }
 
     static get SPAN_MULTIPLE_TILES(): boolean {
@@ -445,12 +502,16 @@ export default class Settings {
         right: number;
     } {
         // get the gaps settings and scale by scale factor
-        const value = this.INNER_GAPS * scaleFactor;
+        const valueTop = this.INNER_GAPS_TOP * scaleFactor;
+        const valueBottom = this.INNER_GAPS_BOTTOM * scaleFactor;
+        const valueLeft = this.INNER_GAPS_LEFT * scaleFactor;
+        const valueRight = this.INNER_GAPS_RIGHT * scaleFactor;
+
         return {
-            top: value,
-            bottom: value,
-            left: value,
-            right: value,
+            top: valueTop,
+            bottom: valueBottom,
+            left: valueLeft,
+            right: valueRight,
         };
     }
 
@@ -461,12 +522,16 @@ export default class Settings {
         right: number;
     } {
         // get the gaps settings and scale by scale factor
-        const value = this.OUTER_GAPS * scaleFactor;
+        const valueTop = this.OUTER_GAPS_TOP * scaleFactor;
+        const valueBottom = this.OUTER_GAPS_BOTTOM * scaleFactor;
+        const valueLeft = this.OUTER_GAPS_LEFT * scaleFactor;
+        const valueRight = this.OUTER_GAPS_RIGHT * scaleFactor;
+
         return {
-            top: value,
-            bottom: value,
-            left: value,
-            right: value,
+            top: valueTop,
+            bottom: valueBottom,
+            left: valueLeft,
+            right: valueRight,
         };
     }
 


### PR DESCRIPTION
# Fix #131

Hi @domferr,

I hope you're doing well! 

Following our previous discussion about customizable gaps, I've implemented the feature that allows separate configuration for each inner and outer gap (left/right/top/bottom). I've tested the code and everything is working fine.

The changes introduce individual controls for:
- Inner gaps (left, right, top, bottom)
- Outer gaps (left, right, top, bottom)

I'd appreciate your review when you have time. Let me know if you'd like me to explain any part of the implementation in more detail.

Thanks! 🚀 

<br>

> Requested by me in issue #131 on Aug 23, 2024.