### PR TITLE
feat: add sync layout option to snap assist

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
@@ -27,6 +27,11 @@
             <summary>Enable snap assist</summary>
             <description>Move the window on top of the screen to snap assist it.</description>
         </key>
+        <key name="snap-assist-sync-layout" type="b">
+            <default>false</default>
+            <summary>Sync layout when tiling with Snap Assistant</summary>
+            <description>Change the desktop layout to match the layout used when tiling a window with Snap Assistant.</description>
+        </key>
         <key name="show-indicator" type="b">
             <default>true</default>
             <summary>Shows indicator</summary>

--- a/src/components/tilingsystem/tilingManager.ts
+++ b/src/components/tilingsystem/tilingManager.ts
@@ -846,6 +846,14 @@ export class TilingManager {
         });
         this._easeWindowRect(window, desiredWindowRect);
 
+        // Sync the desktop layout to match the snap-assisted layout if enabled
+        if (wasSnapAssistingLayout && Settings.SNAP_ASSIST_SYNC_LAYOUT) {
+            GlobalState.get().setSelectedLayoutOfMonitor(
+                wasSnapAssistingLayout.id,
+                this._monitor.index,
+            );
+        }
+
         if (!tilingLayout || !canShowTilingSuggestions) return;
 
         // retrieve the current layout for the monitor and workspace

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -200,6 +200,20 @@ export default class TilingShellExtensionPreferences extends ExtensionPreference
         );
         behaviourGroup.add(snapAssistRow);
 
+        const snapAssistSyncLayoutRow = this._buildSwitchRow(
+            Settings.KEY_SNAP_ASSIST_SYNC_LAYOUT,
+            _('Sync layout when tiling with Snap Assistant'),
+            _(
+                'Change the desktop layout to match the layout used when tiling a window with Snap Assistant',
+            ),
+        );
+        Settings.bind(
+            Settings.KEY_SNAP_ASSIST,
+            snapAssistSyncLayoutRow,
+            'sensitive',
+        );
+        behaviourGroup.add(snapAssistSyncLayoutRow);
+
         const enableTilingSystemRow = this._buildSwitchRow(
             Settings.KEY_TILING_SYSTEM,
             _('Enable Tiling System'),

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -82,6 +82,7 @@ export default class Settings {
     static KEY_WINDOW_USE_CUSTOM_BORDER_COLOR = 'window-use-custom-border-color';
     static KEY_TILING_SYSTEM = 'enable-tiling-system';
     static KEY_SNAP_ASSIST = 'enable-snap-assist';
+    static KEY_SNAP_ASSIST_SYNC_LAYOUT = 'snap-assist-sync-layout';
     static KEY_SHOW_INDICATOR = 'show-indicator';
     static KEY_TILING_SYSTEM_ACTIVATION_KEY = 'tiling-system-activation-key';
     static KEY_TILING_SYSTEM_DEACTIVATION_KEY = 'tiling-system-deactivation-key';
@@ -192,6 +193,14 @@ export default class Settings {
 
     static set SNAP_ASSIST(val: boolean) {
         set_boolean(Settings.KEY_SNAP_ASSIST, val);
+    }
+
+    static get SNAP_ASSIST_SYNC_LAYOUT(): boolean {
+        return get_boolean(Settings.KEY_SNAP_ASSIST_SYNC_LAYOUT);
+    }
+
+    static set SNAP_ASSIST_SYNC_LAYOUT(val: boolean) {
+        set_boolean(Settings.KEY_SNAP_ASSIST_SYNC_LAYOUT, val);
     }
 
     static get SHOW_INDICATOR(): boolean {


### PR DESCRIPTION
This addresses #269 which describes behavior that I think is desirable. When the new sync layout option is enabled, if a window is tiled using the snap assistant and the tile dropped onto corresponds to a different layout than what is active for that desktop, the desktop's layout will be set to the one selected in the snap assistant.

For me, this behavior is the purpose of using the snap assistant 100% of the time. However, I've gated the feature behind an option, because I see from the discussion on #269 that there is not agreement on this point.