### PR TITLE
Feat: topology persistance

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.tilingshell.gschema.xml
@@ -62,6 +62,11 @@
             <summary>Selected layouts</summary>
             <description>Each monitor's active layout used by the monitor tiling manager.</description>
         </key>
+        <key name="selected-layouts-by-topology" type="s">
+            <default>'{}'</default>
+            <summary>Selected layouts by topology</summary>
+            <description>Layout selections keyed by the current monitor topology.</description>
+        </key>
         <key name="restore-window-original-size" type="b">
             <default>true</default>
             <summary>Restore window size</summary>

--- a/src/components/tilingsystem/tilingManager.ts
+++ b/src/components/tilingsystem/tilingManager.ts
@@ -162,7 +162,7 @@ export class TilingManager {
     public enable() {
         this._signals.connect(
             Settings,
-            Settings.KEY_SETTING_SELECTED_LAYOUTS,
+            Settings.KEY_SETTING_SELECTED_LAYOUTS_BY_TOPOLOGY,
             () => {
                 const ws = global.workspaceManager.get_active_workspace();
                 if (!ws) return;

--- a/src/indicator/defaultMenu.ts
+++ b/src/indicator/defaultMenu.ts
@@ -184,7 +184,7 @@ export default class DefaultMenu implements CurrentMenu {
         // if the selected layout was changed externaly, update the selected button
         this._signals.connect(
             Settings,
-            Settings.KEY_SETTING_SELECTED_LAYOUTS,
+            Settings.KEY_SETTING_SELECTED_LAYOUTS_BY_TOPOLOGY,
             () => {
                 this._updateScaling();
                 if (this._layoutsRows.length !== getMonitors().length)

--- a/src/utils/globalState.ts
+++ b/src/utils/globalState.ts
@@ -82,7 +82,7 @@ export default class GlobalState extends GObject.Object {
 
         this._signals.connect(
             Settings,
-            Settings.KEY_SETTING_SELECTED_LAYOUTS,
+            Settings.KEY_SETTING_SELECTED_LAYOUTS_BY_TOPOLOGY,
             () => {
                 const selected_layouts = Settings.get_selected_layouts();
                 if (selected_layouts.length === 0) {

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -4,6 +4,61 @@ import { Monitor } from 'resource:///org/gnome/shell/ui/layout.js';
 
 export const getMonitors = (): Monitor[] => Main.layoutManager.monitors;
 
+export const getMonitorTopologyKey = (): string => {
+    const monitors = getMonitors();
+    const entries = monitors.map((monitor, index) => {
+        const typedMonitor = monitor as {
+            x: number;
+            y: number;
+            width: number;
+            height: number;
+            scale?: number;
+            connector?: string;
+            name?: string;
+            displayName?: string;
+            vendor?: string;
+            product?: string;
+            serial?: string;
+        };
+
+        const identityParts = [
+            typedMonitor.connector,
+            typedMonitor.name,
+            typedMonitor.displayName,
+            typedMonitor.vendor,
+            typedMonitor.product,
+            typedMonitor.serial,
+        ].filter(Boolean);
+
+        if (identityParts.length === 0) identityParts.push(`index:${index}`);
+
+        return {
+            identity: identityParts.join('|'),
+            x: typedMonitor.x,
+            y: typedMonitor.y,
+            width: typedMonitor.width,
+            height: typedMonitor.height,
+            scale: typedMonitor.scale ?? 1,
+        };
+    });
+
+    entries.sort(
+        (a, b) =>
+            a.x - b.x ||
+            a.y - b.y ||
+            a.width - b.width ||
+            a.height - b.height ||
+            a.identity.localeCompare(b.identity),
+    );
+
+    return entries
+        .map(
+            (entry) =>
+                `${entry.identity}@${entry.width}x${entry.height}+${entry.x}+${entry.y}*${entry.scale}`,
+        )
+        .join('||');
+};
+
 export const isPointInsideRect = (
     point: { x: number; y: number },
     rect: Mtk.Rectangle,


### PR DESCRIPTION
Preserve and restore per-monitor layout selections for different physical monitor topologies so users keep expected layouts when displays change.

Migrate existing legacy selections stored in selected-layouts into a topology-scoped mapping to avoid losing selections when monitor arrangement changes.

Reduce needless churn by preferring stable monitor identifiers and only falling back to an index when no identity metadata is available.