### PR TITLE
fix: restore Super key activation for tiling mode (regression from 64afeba)

### DIFF
--- a/src/components/tilingsystem/tilingManager.ts
+++ b/src/components/tilingsystem/tilingManager.ts
@@ -580,10 +580,12 @@ export class TilingManager {
                 mask = Clutter.ModifierType.MOD1_MASK;
                 break;
             case ActivationKey.SUPER:
-                mask = Clutter.ModifierType.SUPER_MASK;
+                // global.get_pointer() returns MOD4_MASK for the Super key,
+                // not SUPER_MASK (which has a different bit position).
+                mask = Clutter.ModifierType.MOD4_MASK;
                 break;
         }
-        return (modifier & mask) === mask;
+        return (modifier & mask) !== 0;
     }
 
     private _onMovingWindow(window: Meta.Window, grabOp: number) {


### PR DESCRIPTION
## Problem

Fixes #485 — After updating from v17.2 to v17.3, pressing the Super key while dragging a window no longer triggers tiling mode.

## Root Cause

Commit 64afeba (`refactor: use Clutter.ModifierType as mask`) introduced two issues:

1. **Wrong mask for Super key**: `Clutter.ModifierType.SUPER_MASK` (bit 26, value `0x4000000`) was used, but `global.get_pointer()` returns `MOD4_MASK` (bit 6, value `64`) for the Super key. These are different bit positions in the modifier bitmask — `SUPER_MASK` is a GDK4-style semantic mask, while `MOD4_MASK` is what Clutter/Mutter actually reports at runtime.

2. **Overly strict comparison**: The check was changed from `(modifier & mask) !== 0` to `(modifier & mask) === mask`. The strict equality fails when additional modifier bits are set alongside the target key (which commonly happens with Super).

The old magic numbers (`val = 2, 3, 6` as bit positions) happened to be correct: `1 << 6 = 64 = MOD4_MASK`, which matches what `global.get_pointer()` returns for Super.

## Fix

- Use `Clutter.ModifierType.MOD4_MASK` instead of `SUPER_MASK` for the Super key
- Restore `!== 0` comparison for robustness (matches behavior of other modifier checks in the codebase, e.g., `hoverLine.ts` and `layoutEditor.ts`)

This preserves the intent of 64afeba (using named enum constants instead of magic numbers) while fixing the regression.