### PR TITLE
fix Super modifier with Gnome 50

### DIFF
--- a/src/components/tilingsystem/tilingManager.ts
+++ b/src/components/tilingsystem/tilingManager.ts
@@ -580,7 +580,7 @@ export class TilingManager {
                 mask = Clutter.ModifierType.MOD1_MASK;
                 break;
             case ActivationKey.SUPER:
-                mask = Clutter.ModifierType.SUPER_MASK;
+                mask = Clutter.ModifierType.MOD4_MASK;
                 break;
         }
         return (modifier & mask) === mask;


### PR DESCRIPTION
global.get_pointer() returns XKB-serialized modifiers where the Super key is reported as MOD4_MASK (bit 6), not SUPER_MASK (bit 26). SUPER_MASK is a virtual/named modifier that is not present in the XKB state returned by xkb_state_serialize_mods().

This is consistent with how ALT is already handled using MOD1_MASK.

See also Mutter commit c0fd2d9556 ("core: Let key presses of special modifiers through") which changed overlay key handling to propagate the initial Super press event rather than consuming it.